### PR TITLE
Resend credentials periodically with backoff

### DIFF
--- a/docs/Signaling.md
+++ b/docs/Signaling.md
@@ -31,6 +31,7 @@ stateDiagram-v2
     Unknown --> Idle: 1. Create new agent<br>2. Send local credentials
 
     Idle --> New: On remote credentials<br>1. Start gathering local candidates
+    Idle --> Idle: Repeatedly send local credentials with back-off
 
     New --> Connecting: On remote candidate<br>1. Connect
     Connecting --> Checking

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/nftables v0.0.0-20220808154552-2eca00135732
+	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pion/ice/v2 v2.2.7
 	github.com/pion/logging v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=
 github.com/josharian/native v1.0.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/pkg/feat/epdisc/epdisc.go
+++ b/pkg/feat/epdisc/epdisc.go
@@ -121,7 +121,6 @@ func (e *EndpointDiscovery) OnInterfaceModified(ci *core.Interface, old *wg.Devi
 		}
 
 		if m.Is(core.InterfaceModifiedPrivateKey) {
-
 			skOld := crypto.Key(old.PrivateKey)
 			if err := p.Resubscribe(context.Background(), skOld); err != nil {
 				e.logger.Error("Failed to update subscription", zap.Error(err))

--- a/pkg/rpc/server_daemon.go
+++ b/pkg/rpc/server_daemon.go
@@ -90,5 +90,5 @@ func (s *DaemonServer) Restart(ctx context.Context, params *proto.Empty) (*proto
 		return nil, status.Error(codes.Unimplemented, "not supported on this platform")
 	}
 
-	return nil, nil
+	return &proto.Empty{}, nil
 }

--- a/pkg/signaling/grpc/config.go
+++ b/pkg/signaling/grpc/config.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	credsinsecure "google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"riasc.eu/wice/pkg/signaling"
 	"riasc.eu/wice/pkg/util/buildinfo"
 )
@@ -68,6 +70,9 @@ func (c *BackendConfig) Parse(cfg *signaling.BackendConfig) error {
 	c.Options = append(c.Options,
 		grpc.WithTransportCredentials(creds),
 		grpc.WithUserAgent(buildinfo.UserAgent()),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: 10 * time.Second,
+		}),
 	)
 
 	if c.URI.Host == "" {

--- a/pkg/signaling/grpc/server.go
+++ b/pkg/signaling/grpc/server.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	"riasc.eu/wice/pkg/crypto"
 	"riasc.eu/wice/pkg/proto"
@@ -41,12 +43,17 @@ func NewServer(opts ...grpc.ServerOption) *Server {
 		}
 
 		opts = slices.Clone(opts)
-		opts = append(opts, grpc.Creds(
-			credentials.NewTLS(&tls.Config{
-				MinVersion:   tls.VersionTLS13,
-				KeyLogWriter: wr,
+		opts = append(opts,
+			grpc.Creds(
+				credentials.NewTLS(&tls.Config{
+					MinVersion:   tls.VersionTLS13,
+					KeyLogWriter: wr,
+				}),
+			),
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime: 5 * time.Second,
 			}),
-		))
+		)
 	}
 
 	s := &Server{

--- a/pkg/signaling/subscriptions.go
+++ b/pkg/signaling/subscriptions.go
@@ -104,7 +104,8 @@ func (s *SubscriptionsRegistry) Subscribe(kp *crypto.KeyPair, h MessageHandler) 
 }
 
 func (s *SubscriptionsRegistry) Unsubscribe(kp *crypto.KeyPair, h MessageHandler) (bool, error) {
-	sub, err := s.GetSubscription(&kp.Ours)
+	pk := kp.Ours.PublicKey()
+	sub, err := s.GetSubscription(&pk)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This is required if agents in different peers are started while having a broken signaling link which causes the initial credentials to never be received.

We now use a backoff time to resend these initial credentials periodically.